### PR TITLE
Add Torteu promo button to result modals

### DIFF
--- a/src/components/modals/LostModal.tsx
+++ b/src/components/modals/LostModal.tsx
@@ -97,17 +97,6 @@ export const LostModal = ({
                 </div>
               </div>
               <div className="sm:mt-2 grid gap-2 grid-cols-1 max-w-full">
-                <a
-                  href="https://torteu.kz/"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="relative inline-flex items-center justify-center w-full rounded-md border border-transparent shadow-sm px-4 py-2 bg-amber-500 text-base font-medium text-white hover:bg-amber-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-amber-400 sm:text-sm"
-                >
-                  Төртеу түгел ойынын ашу
-                  <span className="absolute -top-2 -right-2 inline-flex items-center rounded-full bg-white px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-amber-600 shadow">
-                    жаңа
-                  </span>
-                </a>
                 <TwitterShareButton title={generateMessage(guesses)} url={WORDLE_DOMAIN}>
                    <button
                     type="button"
@@ -139,6 +128,17 @@ export const LostModal = ({
                   <DuplicateIcon className="h-6 w-6 pr-1" />
                   Нәтижені көшіру
                 </button>
+                <a
+                  href="https://torteu.kz/"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="relative inline-flex items-center justify-center w-full rounded-md border border-transparent shadow-sm px-4 py-2 bg-amber-500 text-base font-medium text-white hover:bg-amber-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-amber-400 sm:text-sm"
+                >
+                  Төртеу түгел ойынын көру
+                  <span className="absolute -top-2 -right-2 inline-flex items-center rounded-full bg-white px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-amber-600 shadow">
+                    жаңа
+                  </span>
+                </a>
               </div>
             </div>
           </Transition.Child>

--- a/src/components/modals/LostModal.tsx
+++ b/src/components/modals/LostModal.tsx
@@ -96,7 +96,18 @@ export const LostModal = ({
                   </div>
                 </div>
               </div>
-              <div className="sm:mt-2 grid gap-2 grid-cols-1 grid-rows-3 max-w-full">
+              <div className="sm:mt-2 grid gap-2 grid-cols-1 max-w-full">
+                <a
+                  href="https://torteu.kz/"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="relative inline-flex items-center justify-center w-full rounded-md border border-transparent shadow-sm px-4 py-2 bg-amber-500 text-base font-medium text-white hover:bg-amber-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-amber-400 sm:text-sm"
+                >
+                  Төртеу түгел ойынын ашу
+                  <span className="absolute -top-2 -right-2 inline-flex items-center rounded-full bg-white px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-amber-600 shadow">
+                    жаңа
+                  </span>
+                </a>
                 <TwitterShareButton title={generateMessage(guesses)} url={WORDLE_DOMAIN}>
                    <button
                     type="button"

--- a/src/components/modals/WinModal.tsx
+++ b/src/components/modals/WinModal.tsx
@@ -101,7 +101,18 @@ export const WinModal = ({
                   </div>
                 </div>
               </div>
-              <div className="sm:mt-2 grid gap-2 grid-cols-1 grid-rows-3 max-w-full">
+              <div className="sm:mt-2 grid gap-2 grid-cols-1 max-w-full">
+                <a
+                  href="https://torteu.kz/"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="relative inline-flex items-center justify-center w-full rounded-md border border-transparent shadow-sm px-4 py-2 bg-amber-500 text-base font-medium text-white hover:bg-amber-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-amber-400 sm:text-sm"
+                >
+                  Төртеу түгел ойынын ашу
+                  <span className="absolute -top-2 -right-2 inline-flex items-center rounded-full bg-white px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-amber-600 shadow">
+                    жаңа
+                  </span>
+                </a>
                 <TwitterShareButton title={generateMessage(guesses)} url={WORDLE_DOMAIN}>
                    <button
                     type="button"

--- a/src/components/modals/WinModal.tsx
+++ b/src/components/modals/WinModal.tsx
@@ -102,17 +102,6 @@ export const WinModal = ({
                 </div>
               </div>
               <div className="sm:mt-2 grid gap-2 grid-cols-1 max-w-full">
-                <a
-                  href="https://torteu.kz/"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="relative inline-flex items-center justify-center w-full rounded-md border border-transparent shadow-sm px-4 py-2 bg-amber-500 text-base font-medium text-white hover:bg-amber-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-amber-400 sm:text-sm"
-                >
-                  Төртеу түгел ойынын ашу
-                  <span className="absolute -top-2 -right-2 inline-flex items-center rounded-full bg-white px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-amber-600 shadow">
-                    жаңа
-                  </span>
-                </a>
                 <TwitterShareButton title={generateMessage(guesses)} url={WORDLE_DOMAIN}>
                    <button
                     type="button"
@@ -144,6 +133,17 @@ export const WinModal = ({
                   <DuplicateIcon className="h-6 w-6 pr-1" />
                   Нәтижені көшіру
                 </button>
+                <a
+                  href="https://torteu.kz/"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="relative inline-flex items-center justify-center w-full rounded-md border border-transparent shadow-sm px-4 py-2 bg-amber-500 text-base font-medium text-white hover:bg-amber-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-amber-400 sm:text-sm"
+                >
+                  Төртеу түгел ойынын көру
+                  <span className="absolute -top-2 -right-2 inline-flex items-center rounded-full bg-white px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-amber-600 shadow">
+                    жаңа
+                  </span>
+                </a>
               </div>
             </div>
           </Transition.Child>


### PR DESCRIPTION
## Summary
- add a promotional button with a "жаңа" badge to the win and loss result modals
- adjust the action grid layout to accommodate the new button

## Testing
- npm test -- --watchAll=false *(fails: existing suite expects ResizeObserver in jsdom)*

------
https://chatgpt.com/codex/tasks/task_e_68d109fc7ae883338145470cbb09f9ea