### PR TITLE
Use Firebase server time for daily word selection

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,15 +3,10 @@ import ReactDOM from 'react-dom'
 import './index.css'
 import App from './App'
 // import reportWebVitals from './reportWebVitals'
-import { initializeApp } from 'firebase/app';
-import { getAnalytics } from "firebase/analytics";
-
-ReactDOM.render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>,
-  document.getElementById('root')
-)
+import { initializeApp } from 'firebase/app'
+import { getAnalytics } from 'firebase/analytics'
+import { getDatabase, ref, get } from 'firebase/database'
+import { initializeWordOfDay } from './lib/words'
 
 // Your web app's Firebase configuration
 const firebaseConfig = {
@@ -25,5 +20,40 @@ const firebaseConfig = {
 };
 
 // Initialize Firebase
-const app = initializeApp(firebaseConfig);
-const analytics = getAnalytics(app);
+const app = initializeApp(firebaseConfig)
+getAnalytics(app)
+
+const fetchGoogleTime = async (): Promise<number> => {
+  const database = getDatabase(app)
+  const offsetSnapshot = await get(ref(database, '.info/serverTimeOffset'))
+  const offset = offsetSnapshot.val()
+
+  if (typeof offset === 'number') {
+    return Date.now() + offset
+  }
+
+  throw new Error('Google time offset unavailable')
+}
+
+const renderApplication = () => {
+  ReactDOM.render(
+    <React.StrictMode>
+      <App />
+    </React.StrictMode>,
+    document.getElementById('root')
+  )
+}
+
+const bootstrap = async () => {
+  try {
+    const googleTimestamp = await fetchGoogleTime()
+    initializeWordOfDay(googleTimestamp)
+  } catch (error) {
+    console.error('Falling back to device time for word of the day', error)
+    initializeWordOfDay(Date.now())
+  } finally {
+    renderApplication()
+  }
+}
+
+bootstrap()

--- a/src/lib/words.ts
+++ b/src/lib/words.ts
@@ -16,7 +16,7 @@ const normalizeIndex = (rawIndex: number) => {
 
 const computeWordOfDayFromTimestamp = (timestamp: number): WordOfDay => {
   const dayOfYear = Number(moment(timestamp).tz(GAME_TIMEZONE).format('DDD'))
-  const index = normalizeIndex(dayOfYear)
+  const index = normalizeIndex(dayOfYear - 1)
 
   return {
     solution: WORDS[index].toUpperCase(),

--- a/src/lib/words.ts
+++ b/src/lib/words.ts
@@ -16,7 +16,7 @@ const normalizeIndex = (rawIndex: number) => {
 
 const computeWordOfDayFromTimestamp = (timestamp: number): WordOfDay => {
   const dayOfYear = Number(moment(timestamp).tz(GAME_TIMEZONE).format('DDD'))
-  const index = normalizeIndex(dayOfYear - 1)
+  const index = normalizeIndex(dayOfYear)
 
   return {
     solution: WORDS[index].toUpperCase(),

--- a/src/lib/words.ts
+++ b/src/lib/words.ts
@@ -1,6 +1,39 @@
 import { WORDS } from '../constants/wordlist'
 import { VALIDGUESSES } from '../constants/validGuesses'
-import moment from 'moment-timezone';
+import moment from 'moment-timezone'
+
+type WordOfDay = {
+  solution: string
+  solutionIndex: number
+}
+
+const GAME_TIMEZONE = 'Asia/Aqtau'
+
+const normalizeIndex = (rawIndex: number) => {
+  const wrappedIndex = rawIndex % WORDS.length
+  return wrappedIndex < 0 ? wrappedIndex + WORDS.length : wrappedIndex
+}
+
+const computeWordOfDayFromTimestamp = (timestamp: number): WordOfDay => {
+  const dayOfYear = Number(moment(timestamp).tz(GAME_TIMEZONE).format('DDD'))
+  const index = normalizeIndex(dayOfYear - 1)
+
+  return {
+    solution: WORDS[index].toUpperCase(),
+    solutionIndex: dayOfYear,
+  }
+}
+
+let cachedWordOfDay: WordOfDay = computeWordOfDayFromTimestamp(Date.now())
+export let solution = cachedWordOfDay.solution
+export let solutionIndex = cachedWordOfDay.solutionIndex
+
+export const initializeWordOfDay = (timestamp: number) => {
+  cachedWordOfDay = computeWordOfDayFromTimestamp(timestamp)
+  solution = cachedWordOfDay.solution
+  solutionIndex = cachedWordOfDay.solutionIndex
+  return cachedWordOfDay
+}
 
 export const isWordInWordList = (word: string) => {
   return (
@@ -13,22 +46,4 @@ export const isWinningWord = (word: string) => {
   return solution === word
 }
 
-export const getWordOfDay = () => {
-  // January 1, 2022 Game Epoch
-  // const epochMs = 1641013200000
-  // const now = Date.now()
-  // const msInDay = 86400000
-  // const index = Math.floor((now - epochMs) / msInDay)
-  moment.tz.setDefault("Asia/Aqtau");// change this to UTC +5
-  moment.tz.setDefault("")
-  const index = moment().format('DDD');
-   console.log(moment().format('HH:mm:ss'));
-  // console.log(moment().format());
-
-  return {
-    solution: WORDS[index].toUpperCase(),
-    solutionIndex: index,
-  }
-}
-
-export const { solution, solutionIndex } = getWordOfDay()
+export const getWordOfDay = () => cachedWordOfDay


### PR DESCRIPTION
## Summary
- fetch Google-provided server time via Firebase Realtime Database before rendering the app
- centralize daily word calculation logic so the fetched timestamp defines the solution

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d79853fa388333a479c9ca0ad88e9b