### PR TITLE
Add submission link to main page footer

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -267,6 +267,17 @@ function App() {
         handleClose={() => setIsStatsModalOpen(false)}
         stats={stats}
       />
+
+      <footer className="text-center text-sm text-slate-600 py-4">
+        <a
+          href="https://docs.google.com/forms/d/e/1FAIpQLSfwai0b117UpDxqGgCLoKtSnuhj6HbwAB9c63IpL3zXi0AQOQ/viewform"
+          target="_blank"
+          rel="noreferrer"
+          className="underline"
+        >
+          Өз сөзімді ұсыну
+        </a>
+      </footer>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- add a footer link on the main page that points to the Google Form for submitting words

## Testing
- npm start

------
https://chatgpt.com/codex/tasks/task_e_68edf620da008333817a33fd6782a1ce